### PR TITLE
Hamlib cw (#294)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,10 @@ AC_CHECK_LIB([hamlib], [rig_open], [
                 [Define to 1 if you have the `hamlib' library (-lhamlib).])], [
         AC_MSG_ERROR([Hamradio control libraries not found!])])
 
+AC_DEFINE_UNQUOTED([HAMLIB_VERSION],
+    [`$PKG_CONFIG --modversion hamlib | awk '{print int($1*100)}'`],
+        [Hamlib version (times 100)])
+
 LIBS=$tlf_saved_LIBS
 
 tlf_saved_CFLAGS=$CFLAGS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ tlf_SOURCES = \
 	genqtclist.c \
 	get_time.c getctydata.c getexchange.c getmessages.c getpx.c \
 	gettxinfo.c getwwv.c grabspot.c \
+	hamlib_keyer.c \
 	initial_exchange.c \
 	keyer.c \
 	lancode.c last10.c listmessages.c log_to_disk.c log_utils.c \
@@ -52,6 +53,7 @@ noinst_HEADERS = \
 	genqtclist.h \
 	get_time.h  getctydata.h getexchange.h getmessages.h getpx.h \
 	gettxinfo.h getwwv.h globalvars.h grabspot.h \
+	hamlib_keyer.h \
 	ignore_unused.h initial_exchange.h \
 	keyer.h keystroke_names.h \
 	lancode.h last10.h listmessages.h log_utils.h \

--- a/src/gettxinfo.c
+++ b/src/gettxinfo.c
@@ -28,10 +28,12 @@
 #include <pthread.h>
 
 #include "bands.h"
+#include "cw_utils.h"
 #include "err_utils.h"
 #include "fldigixmlrpc.h"
 #include "gettxinfo.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "tlf.h"
 #include "tlf_curses.h"
 #include "callinput.h"
@@ -188,12 +190,29 @@ void gettxinfo(void) {
 	    handle_trx_bandswitch((int) freq);
 	}
 
+	/* read speed from rig */
+	if (cwkeyer == HAMLIB_KEYER) {
+	    int rig_cwspeed;
+	    retval = hamlib_keyer_get_speed(&rig_cwspeed);
+
+	    if (retval == RIG_OK) {
+		if (GetCWSpeed() != rig_cwspeed) { // FIXME: doesn't work if rig speed is between the values from CW_SPEEDS
+		    SetCWSpeed(rig_cwspeed);
+
+		    attron(COLOR_PAIR(C_HEADER) | A_STANDOUT);
+		    mvprintw(0, 14, "%2u", GetCWSpeed());
+		}
+	    } else {
+		TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
+	    }
+	}
+
     } else if (reqf == SETCWMODE) {
 
 	retval = rig_set_mode(my_rig, RIG_VFO_CURR, RIG_MODE_CW, get_cw_bandwidth());
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link!");
+	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else if (reqf == SETSSBMODE) {
@@ -202,7 +221,7 @@ void gettxinfo(void) {
 			      TLF_DEFAULT_PASSBAND);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link!");
+	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else if (reqf == SETDIGIMODE) {
@@ -217,14 +236,14 @@ void gettxinfo(void) {
 			      TLF_DEFAULT_PASSBAND);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link!");
+	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else if (reqf == RESETRIT) {
 	retval = rig_set_rit(my_rig, RIG_VFO_CURR, 0);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link!");
+	    TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
 	}
 
     } else {
@@ -233,7 +252,7 @@ void gettxinfo(void) {
 	retval = rig_set_freq(my_rig, RIG_VFO_CURR, (freq_t) reqf);
 
 	if (retval != RIG_OK) {
-	    TLF_LOG_WARN("Problem with rig link: set frequency!");
+	    TLF_LOG_WARN("Problem with rig link: set frequency: %s", rigerror(retval));
 	}
 
     }
@@ -274,7 +293,7 @@ static void handle_trx_bandswitch(const freq_t freq) {
     int retval = rig_set_mode(my_rig, RIG_VFO_CURR, mode, width);
 
     if (retval != RIG_OK) {
-	TLF_LOG_WARN("Problem with rig link!");
+	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retval));
     }
 
 }

--- a/src/hamlib_keyer.c
+++ b/src/hamlib_keyer.c
@@ -1,0 +1,65 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2001-2002-2003-2004-2005 Rein Couperus <pa0r@amsat.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <assert.h>
+#include <hamlib/rig.h>
+
+#include "globalvars.h"
+#include "hamlib_keyer.h"
+
+bool rig_has_send_morse() {
+   return (my_rig->caps->send_morse != NULL);
+}
+
+bool rig_has_stop_morse() {
+#if HAMLIB_VERSION >= 400
+    return (my_rig->caps->stop_morse != NULL);
+#else
+    return false;
+#endif
+}
+
+int hamlib_keyer_set_speed(int cwspeed) {
+    value_t spd;
+    spd.i = cwspeed;
+
+    return rig_set_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, spd);
+}
+
+int hamlib_keyer_get_speed( int *cwspeed) {
+    value_t value;
+
+    assert (cwspeed != NULL);
+    int ret = rig_get_level(my_rig, RIG_VFO_CURR, RIG_LEVEL_KEYSPD, &value);
+    if (ret == RIG_OK)
+	*cwspeed = value.i;
+    return ret;
+}
+
+int hamlib_keyer_send(char *cwmessage) {
+    return rig_send_morse(my_rig, RIG_VFO_CURR, cwmessage);
+}
+
+int hamlib_keyer_stop() {
+    if (rig_has_stop_morse()) {
+	return rig_stop_morse(my_rig, RIG_VFO_CURR);
+    } else {
+	return RIG_OK;
+    }
+}

--- a/src/hamlib_keyer.h
+++ b/src/hamlib_keyer.h
@@ -1,0 +1,25 @@
+/*
+ * Tlf - contest logging program for amateur radio operators
+ * Copyright (C) 2001-2002-2003-2004-2005 Rein Couperus <pa0r@amsat.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+bool rig_has_send_morse();
+bool rig_has_stop_morse();
+int hamlib_keyer_set_speed(int cwspeed);
+int hamlib_keyer_get_speed( int *cwspeed);
+int hamlib_keyer_send(char *cwmessage);
+int hamlib_keyer_stop();

--- a/src/keyer.c
+++ b/src/keyer.c
@@ -157,7 +157,7 @@ void keyer(void) {
 	if ((x >= ' ' && x <= 'Z') || x == LINEFEED) { /* ~printable or LF */
 	    if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER) {
 		mfj1278_control(x);
-	    } else if (cwkeyer == NET_KEYER) {
+	    } else if (cwkeyer == NET_KEYER || cwkeyer == HAMLIB_KEYER) {
 		keyer_append_char(x);
 	    }
 

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "getmessages.h"
 #include "getwwv.h"
 #include "globalvars.h"		// Includes glib.h and tlf.h
+#include "hamlib_keyer.h"
 #include "initial_exchange.h"
 #include "lancode.h"
 #include "logit.h"
@@ -827,6 +828,34 @@ static void keyer_init() {
 
     }
 
+    if (cwkeyer == HAMLIB_KEYER) {
+	showmsg("CW-Keyer is Hamlib");
+	if (!trx_control) {
+	    showmsg("Radio control is not activated!!");
+	    sleep(1);
+	    endwin();
+	    exit(EXIT_FAILURE);
+	}
+	if (!rig_has_send_morse()) {
+	    showmsg("Rig does not support CW via Hamlib");
+	    sleep(1);
+	    endwin();
+	    exit(EXIT_FAILURE);
+	}
+	if (!rig_has_stop_morse()) {
+#if HAMLIB_VERSION >= 400
+	    showmsg("Rig does not support stopping CW!!");
+#else
+	    showmsg("Hamlib version does not supprt stopping CW!!");
+#endif
+	    showmsg("Continue anyway Y/(N)?");
+	    if (toupper(key_get()) != 'Y') {
+		endwin();
+		exit(1);
+	    }
+	}
+    }
+
     if (cwkeyer == MFJ1278_KEYER || digikeyer == MFJ1278_KEYER ||
 	    digikeyer == GMFSK) {
 	init_controller();
@@ -960,8 +989,6 @@ int main(int argc, char *argv[]) {
     showmsg("");
 
     memset(&my, 0, sizeof(my));
-
-    rig_set_debug(RIG_DEBUG_NONE);
 
     total = 0;
     if (databases_load() == EXIT_FAILURE) {

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1126,6 +1126,7 @@ static config_t logcfg_configs[] = {
     {"CONTINENT_LIST_POINTS",   CFG_INT(continentlist_points, 0, INT32_MAX)},
 
     {"NETKEYER",        CFG_INT_CONST(cwkeyer, NET_KEYER)},
+    {"HAMLIB_KEYER",    CFG_INT_CONST(cwkeyer, HAMLIB_KEYER)},
     {"FIFO_INTERFACE",  CFG_INT_CONST(packetinterface, FIFO_INTERFACE)},
     {"LONG_SERIAL",     CFG_INT_CONST(shortqsonr, 0)},
     {"CLUSTER",         CFG_INT_CONST(cluster, CLUSTER)},

--- a/src/sendqrg.c
+++ b/src/sendqrg.c
@@ -23,6 +23,9 @@
 #include <unistd.h>
 
 #include "bands.h"
+#include "cw_utils.h"
+#include "err_utils.h"
+#include "hamlib_keyer.h"
 #include "sendqrg.h"
 #include "startmsg.h"
 #include "gettxinfo.h"
@@ -69,6 +72,9 @@ int init_tlf_rig(void) {
     dcd_type_t dcd_type = RIG_DCD_NONE;
 
     const struct rig_caps *caps;
+    int rig_cwspeed;
+
+    rig_set_debug(RIG_DEBUG_NONE);
 
     /*
      * allocate memory, setup & open port
@@ -118,7 +124,7 @@ int init_tlf_rig(void) {
     retcode = rig_open(my_rig);
 
     if (retcode != RIG_OK) {
-	showmsg("rig_open: error ");
+	TLF_LOG_WARN("rig_open: %s", rigerror(retcode));
 	return -1;
     }
 
@@ -129,12 +135,25 @@ int init_tlf_rig(void) {
 	retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
 
     if (retcode != RIG_OK) {
-	showmsg("Problem with rig link!");
+	TLF_LOG_WARN("Problem with rig link: %s", rigerror(retcode));
 	if (!debugflag)
 	    return -1;
     }
 
     shownr("Freq =", (int) rigfreq);
+
+    if (cwkeyer == HAMLIB_KEYER) {
+	retcode = hamlib_keyer_get_speed(&rig_cwspeed); /* read cw speed from rig */
+
+	if (retcode == RIG_OK) {
+	    shownr("CW speed = ", rig_cwspeed);
+	    SetCWSpeed(rig_cwspeed);
+	} else {
+	    TLF_LOG_WARN("Could not read CW speed from rig: %s", rigerror(retcode));
+	    if (!debugflag)
+		return -1;
+	}
+    }
 
     if (debugflag) {	// debug rig control
 	debug_tlf_rig();
@@ -211,8 +230,7 @@ static void debug_tlf_rig() {
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);
 
     if (retcode != RIG_OK) {
-	showmsg("Problem with rig get freq!");
-	sleep(1);
+	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
     } else {
 	shownr("freq =", (int) rigfreq);
     }
@@ -223,8 +241,7 @@ static void debug_tlf_rig() {
     retcode = rig_set_freq(my_rig, RIG_VFO_CURR, testfreq);
 
     if (retcode != RIG_OK) {
-	showmsg("Problem with rig set freq!");
-	sleep(1);
+	TLF_LOG_WARN("Problem with rig set freq: %s", rigerror(retcode));
     } else {
 	showmsg("Rig set freq ok!");
     }
@@ -232,8 +249,7 @@ static void debug_tlf_rig() {
     retcode = rig_get_freq(my_rig, RIG_VFO_CURR, &rigfreq);	// read qrg
 
     if (retcode != RIG_OK) {
-	showmsg("Problem with rig get freq!");
-	sleep(1);
+	TLF_LOG_WARN("Problem with rig get freq: %s", rigerror(retcode));
     } else {
 	shownr("freq =", (int) rigfreq);
 	if (rigfreq != testfreq) {

--- a/src/speedupndown.c
+++ b/src/speedupndown.c
@@ -29,6 +29,7 @@
 #include "cw_utils.h"
 #include "err_utils.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "netkeyer.h"
 #include "sendbuf.h"
 #include "tlf.h"
@@ -39,8 +40,9 @@ void setspeed(void) {
 
     int retval = 0;
     char buff[3];
+    int cwspeed = GetCWSpeed();
 
-    snprintf(buff, 3, "%2u", GetCWSpeed());
+    snprintf(buff, 3, "%2u", cwspeed);
 
     if (cwkeyer == NET_KEYER) {
 
@@ -49,6 +51,16 @@ void setspeed(void) {
 	if (retval < 0) {
 	    TLF_LOG_WARN("keyer not active");
 //                      trxmode = SSBMODE;
+	    clear_display();
+	}
+    }
+
+    if (cwkeyer == HAMLIB_KEYER) {
+
+	retval = hamlib_keyer_set_speed(cwspeed);
+
+	if (retval < 0) {
+	    TLF_LOG_WARN("Could not set CW speed: %s", rigerror(retval));
 	    clear_display();
 	}
     }

--- a/src/stoptx.c
+++ b/src/stoptx.c
@@ -22,9 +22,11 @@
 *--------------------------------------------------------------*/
 
 
+#include <hamlib/rig.h>
 #include "clear_display.h"
 #include "err_utils.h"
 #include "globalvars.h"
+#include "hamlib_keyer.h"
 #include "netkeyer.h"
 #include "tlf.h"
 #include "tlf_curses.h"
@@ -44,6 +46,11 @@ int stoptx(void) {
 		trxmode = SSBMODE;
 		clear_display();
 
+	    }
+	} else if (cwkeyer == HAMLIB_KEYER) {
+	    int error = hamlib_keyer_stop();
+	    if (error != RIG_OK) {
+		TLF_LOG_WARN("CW stop error: %s", rigerror(error));
 	    }
 	}
     } else {

--- a/src/tlf.h
+++ b/src/tlf.h
@@ -32,6 +32,7 @@ enum {
     MFJ1278_KEYER,
     GMFSK,
     FLDIGI,
+    HAMLIB_KEYER,
 };
 
 #define SINGLE 0        /* single op */

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -114,6 +114,10 @@ CW keying via
 is fully supported, featuring direct mode for the keyboard and output to
 parallel and serial ports and speed and weight control from the keyboard, and
 band info output on the parallel port.
+Likewise, CW keying via
+.B Hamlib
+is supported for rigs that feature the capability. Tlf can set the CW speed,
+and at the same time read back the speed if changed using the knob on the rig.
 .
 .P
 For users of the K1EL series of \(lqWin Keyers\(rq, the
@@ -1739,6 +1743,14 @@ Default port is 6789.
 .TP
 \fBNETKEYERHOST\fR=\fIhost_address\fR
 Default host is 127.0.0.1 (localhost).
+.
+.TP
+\fBHAMLIB_KEYER\fR
+Activate CW keying via Hamlib.
+.
+.IP
+.B Note:
+The + and - macros to control speed from within messages are not yet supported.
 .
 .TP
 \fBMFJ1278_KEYER\fR=\fIserial_port\fR


### PR DESCRIPTION
* Supports sending cw via Hamlib command
* Supports set and read keying speed from rig
* Stopping morse message only supported from Hamlib-4.0 on.
  Be aware that not all rigs provide that feature. In that
  case shows a  orningn startup.
* Activate the Hamlib keyer by HAMLIB_KEYER keyword
* + and - macros are not supported

Needs testing with more rigs.

Co-authored-by: zcsahok <ha5cqz@gmx.com>
Co-authored-by: Nick Craig-Wood <nick@craig-wood.com>
Co-authored-by: Thomas Beierlein <dl1jbe@darc.de>